### PR TITLE
TypeSynonymInstances

### DIFF
--- a/applicative-extras.cabal
+++ b/applicative-extras.cabal
@@ -15,3 +15,5 @@ Exposed-Modules:   Control.Applicative.Compose
                  , Control.Applicative.Backwards
 Build-Type:      Simple
 Build-Depends:   base >= 3 && < 5, haskell98, mtl
+Extensions: TypeSynonymInstances
+


### PR DESCRIPTION
Hi,

The package was not installing without the TypeSynonymInstances flag in the .cabal file.

Cheers,
Ozgun
